### PR TITLE
Add maintainer info to Docker image via label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ ENV LANG 'en_US.UTF-8'
 ENV LANGUAGE 'en_US:en'
 ENV LC_ALL 'en_US.UTF-8'
 
+# maintainer information¬
+LABEL maintainer="pelias.team@gmail.com"¬
+
 # configure directories
 RUN mkdir -p '/code/pelias'
 


### PR DESCRIPTION
This was previously found only in the pelias/api image, but it should be everywhere.

I wasn't sure if labels propagate to images that are built on other images, but after some testing it appears that they do.