### PR TITLE
Change base image to use ubuntu 16.04, and add dependency to support valhalla.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'

--- a/packages.sh
+++ b/packages.sh
@@ -10,6 +10,7 @@ packages=(
 "libtool"
 "pkg-config"
 "python" # required for node-gyp, in particular `integer` required by `better-sqlite3`
+"software-properties-common" # required to add valhalla repo
 )
 
 apt-get update && \


### PR DESCRIPTION
Proposed lock down of baseimage version, instead of pulling from ubuntu latest every time an image is built. Version is up for debate, but using this version will allow for easier support of valhalla in the polyline data generation since a recipe exists to install for this version of ubuntu easily.
Alternatively, could just pull in the whole branch and build a separate tag specifically used for the polyline repository to support valhalla if the version lockdown isn't deemed appropriate.