### PR TITLE
fix permissions for VOLUME /data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,7 @@ ENV LC_ALL 'en_US.UTF-8'
 LABEL maintainer="pelias.team@gmail.com"¬
 
 # configure directories
-RUN mkdir -p '/code/pelias'
-
-# configure volumes
-VOLUME "/data"
+RUN mkdir -p /code/pelias /data
 
 # configure git
 RUN git config --global 'user.email' 'pelias.team@gmail.com'
@@ -44,3 +41,8 @@ RUN useradd -ms /bin/bash pelias
 
 # ensure symlinks, pelias.json, and anything else are owned by pelias user
 RUN chown pelias:pelias /data /code -R
+
+# configure volumes
+VOLUME "/data"
+
+


### PR DESCRIPTION
According to the `Dockerfile`, both `/code` and `/data` are intended to be owned by the user `pelias`.
For `/data`, this isn't actually the case, as it is defined as a `VOLUME` **before** permissions are set.

If you accept these changes, please propagate them to the `nodejs-10` branch in order to fix
pelias/interpolation#217 (pelias-interpolation uses `pelias/libpostal_baseimage`, which is based on `pelias/baseimage:nodejs-10`).

Consider this minimal example:

```
$ cat Dockerfile-volume-before-chown
FROM ubuntu:latest

VOLUME "/data"

RUN useradd -ms /bin/bash pelias && \
    mkdir /code && \
    chown pelias:pelias /data /code -R
```

results in the `/data` directory to be owned by `root`:

```
$ docker build -t volume-first -f Dockerfile-volume-before-chown .
[...]
$ docker run -ti volume-first ls -shl /
[...]
4.0K drwxr-xr-x   2 pelias pelias 4.0K Sep 17 14:31 code
4.0K drwxr-xr-x   2 root   root   4.0K Sep 17 14:31 data
[...]
```

When `/data` is created and owned by Pelias **before** it is marked as a `VOLUME`:

```
$ cat Dockerfile-chown-before-volume 
FROM ubuntu:latest

RUN useradd -ms /bin/bash pelias && \
    mkdir /code /data && \
    chown pelias:pelias /data /code -R

VOLUME "/data"
```

permissions work as expected:

```
$ docker build -t chown-first -f Dockerfile-chown-before-volume .
[...]
$ docker run -ti pelias-minimal-permission-baseimage ls -shl /
[...]
4.0K drwxr-xr-x   2 pelias pelias 4.0K Sep 17 14:39 code
4.0K drwxr-xr-x   2 pelias pelias 4.0K Sep 17 14:39 data
[...]
```