### PR TITLE
Add NPM upgrade step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave
 # add global install dir to $NODE_PATH
 ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"
 
+# ensure NPM is up to date
+RUN npm install -g npm
+
 # get ready for pelias config with an empty file
 ENV PELIAS_CONFIG '/code/pelias.json'
 RUN echo '{}' > '/code/pelias.json'


### PR DESCRIPTION
The Pelias base image currently does not have a step to update NPM.

While using a modern version of Node.js will also ensure a reasonably up to date version of NPM, there are times when being very up to date is important.

One of those times is today: NPM just announced a potentially serious vulnerability in the NPM CLI: https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli

This change adds an explicit step to upgrade NPM to the latest version which should help protect against such issues in the future.
