### PR TITLE
Explicitly use Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'


### PR DESCRIPTION
This changes the Ubuntu docker image used from `ubuntu:latest` to `ubuntu:18.04`. Going by the documentation on https://hub.docker.com/_/ubuntu, this change is _currently_  a no-op, but it will prevent changes in the Ubuntu version from unexpectedly appearing in our base image.

The image hashes show this is currently a no-op:
```
julian@rockaway ~/repos/pelias/docker-baseimage $ docker pull ubuntu:18.04
18.04: Pulling from library/ubuntu
Digest: sha256:8d31dad0c58f552e890d68bbfb735588b6b820a46e459672d96e585871acc110
Status: Image is up to date for ubuntu:18.04
docker.io/library/ubuntu:18.04
julian@rockaway ~/repos/pelias/docker-baseimage $ docker pull ubuntu:latest
latest: Pulling from library/ubuntu
Digest: sha256:8d31dad0c58f552e890d68bbfb735588b6b820a46e459672d96e585871acc110
Status: Image is up to date for ubuntu:latest
docker.io/library/ubuntu:latest
```