### PR TITLE
chore - update contact details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ ENV LANG 'en_US.UTF-8'
 ENV LANGUAGE 'en_US:en'
 ENV LC_ALL 'en_US.UTF-8'
 
-# maintainer information¬
-LABEL maintainer="pelias.team@gmail.com"¬
+# maintainer information
+LABEL maintainer="team@pelias.io"
 
 # configure directories
 RUN mkdir -p '/code/pelias'
@@ -25,7 +25,7 @@ RUN mkdir -p '/code/pelias'
 VOLUME "/data"
 
 # configure git
-RUN git config --global 'user.email' 'pelias.team@gmail.com'
+RUN git config --global 'user.email' 'team@pelias.io'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs


### PR DESCRIPTION
`pelias.team@gmail.com` -> `team@pelias.io`
shows up a lot in search engine indexes because it's printed on the Dockerhub pages.

there was a funny little `¬` mark at the end of a couple lines, I'm guessing it was a typo and chose to remove them.

