### PR TITLE
Use Ubuntu 20.04 as base for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'


### PR DESCRIPTION
We're currently pinned to Ubuntu 18.04, which is a nice stable base image, but maybe we should consider upgrading to Ubuntu 20.04? 