### PR TITLE
Remove compiler toolchain and python

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -5,11 +5,6 @@ packages=(
 "curl"
 "wget"
 "git-core"
-"autoconf"
-"automake"
-"libtool"
-"pkg-config"
-"python" # required for node-gyp, in particular `integer` required by `better-sqlite3`
 )
 
 apt-get update && \


### PR DESCRIPTION
We currently include a full compiler toolchain (gcc, autoconf, automake, etc), as well as Python, in our Docker baseimage used for all Pelias Docker images.

This used to be required, since we had several Node.js modules that needed to compile native code.

However, since `better-sqlite3` added support for prebuilt binaries in [version 6.0](https://github.com/JoshuaWise/better-sqlite3/releases/tag/v6.0.0), I don't think we have any such modules left.

Removing all these packages reduces the uncompressed baseimage size from 243MB to 230MB according to Google's [container-diff](https://github.com/GoogleContainerTools/container-diff). That's not huge, but it's not nothing either and if it's free, then why not?

Note that some of our Dockerimages, like whosonfirst and placeholder, include some of these same dependencies, so we'll have to remove them there too.

Closes #21 