### PR TITLE
Upgrade to Node.js 16.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN git config --global 'user.email' 'team@pelias.io'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
-ENV NODE_VERSION='12.22.2'
+ENV NODE_VERSION='16.20.1'
 RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf ~/.nave /code/nave
 
 # add global install dir to $NODE_PATH


### PR DESCRIPTION
Our Docker baseimage is currently on Node.js 12, the lowest version we support. It [_just_ entered LTS](https://nodejs.org/en/about/releases/), so there's no real need to rush on _removing_ it, but Node.js 16 has some nice new features and seemingly better performance.

We've been testing all our repositories on Node.js 16 so things should be pretty smooth. Before merging this I'll perform some additional testing.