### PR TITLE
Update Docker baseimage to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'


### PR DESCRIPTION
This gives us several more years of a supported Ubuntu version, lots of updated default packages, support for modern versions of Node.js and NPM modules, and more.

https://github.com/pelias/pelias/issues/951