### PR TITLE
CI: update Github Action runner Ubuntu versions to 22.04

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on: push
 jobs:
   build-docker-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker images


### PR DESCRIPTION
GitHub is deprecating Ubuntu 20 based runners [on April 1](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), so we want to be off well before then.

Connects https://github.com/pelias/pelias/issues/951