### PR TITLE
Add compression tools to baseimage

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -5,6 +5,9 @@ packages=(
 "curl"
 "wget"
 "git-core"
+"bzip2"
+"lbzip2"
+"unzip"
 )
 
 apt-get update && \


### PR DESCRIPTION
These packages are used across multiple importers to download and extract data, so we can save a lot of time and disk space by putting them in the baseimage instead.