### PR TITLE
Upgrade Node.js to 20.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN git config --global 'user.email' 'team@pelias.io'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
-ENV NODE_VERSION='18.20.5'
+ENV NODE_VERSION='20.19.2'
 RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf ~/.nave /code/nave
 
 # add global install dir to $NODE_PATH


### PR DESCRIPTION
This moves our Docker baseimage to Node.js 20, so we can [drop support for Node.js 18](https://github.com/pelias/pelias/issues/985).