### PR TITLE
Install all small apt packages used across projects

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -8,6 +8,10 @@ packages=(
 "bzip2"
 "lbzip2"
 "unzip"
+"pigz"
+"zstd"
+"time"
+"gawk"
 "libsqlite3-mod-spatialite" # required for spatialite support in sqlite3
 )
 


### PR DESCRIPTION
This consolidates all the `apt-get install` commands across all the importer and service Dockerfiles. Many of them installed small utilities such as compression or decompression tools, often duplicating tools that were already installed in the baseimage.

After the change in this PR, only `interpolation` needs any custom `apt-get install` commands (to bring in big things like `gdal`). Everything else should now be in the baseimage.

This will help keep the tooling we have available more uniform (some of our downloaders only could decompress certain formats for example), and should save a tiny amount of space across all our docker images.